### PR TITLE
Updated dependency: "symfony/property-access": "^4.1 || ^5.2"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "symfony/http-kernel": "^4.1",
     "php-http/guzzle6-adapter": "^1.1",
     "symfony/serializer": "^4.4",
-    "symfony/property-access": "^4.1"
+    "symfony/property-access": "^4.1 || ^5.2"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "symfony/http-kernel": "^4.1",
     "php-http/guzzle6-adapter": "^1.1",
     "symfony/serializer": "^4.4",
-    "symfony/property-access": "^4.1 || ^5.2"
+    "symfony/property-access": "^4.1 || ^5.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
     "ext-json": "*",
     "marc-mabe/php-enum": "^3.0|^4.3",
     "webmozart/assert": "^1.3",
-    "symfony/validator": "^4.1",
-    "symfony/http-kernel": "^4.1",
+    "symfony/validator": "^4.1 || ^5.0",
+    "symfony/http-kernel": "^4.1 || ^5.0",
     "php-http/guzzle6-adapter": "^1.1",
-    "symfony/serializer": "^4.4",
+    "symfony/serializer": "^4.4 || ^5.0",
     "symfony/property-access": "^4.1 || ^5.0"
   },
   "require-dev": {


### PR DESCRIPTION
I just added possibility to get 5.2.* version of symfony/property-access. It seems it passed nicely the Unit Tests (PHPUnit) on my end. Please try it too and let me know whehter it may stay this way, or whehter there must be also other changes made.

Guessing by the package change log, I do not really expect any problems.